### PR TITLE
Fix "No data" in the "Current UPS Status" panel for #4.

### DIFF
--- a/dashboard/PeaNUT Grafana.json
+++ b/dashboard/PeaNUT Grafana.json
@@ -408,10 +408,10 @@
         {
           "id": "filterFieldsByName",
           "options": {
+            "byVariable": false,
             "include": {
-              "names": [
-                "ups.status ZOX1 BACK-UPS XS 1500M"
-              ]
+              "names": [],
+              "pattern": "ups.status.*"
             }
           }
         }


### PR DESCRIPTION
The transformation filter retained only the field named `ups.status ZOX1 BACK-UPS XS 1500M`. This rejected other ups.status field names, such as `ups.status proxmox1:3493`, causing *no data.* The fix recognizes fields with the regular expression `ups.status.*`.